### PR TITLE
Corrected character mapping

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ let bc = new BagOfCrafting(pools, meta);
 // throw new Error();
 
 // 'aaaaaaaa' to [1,1,1,1,1,1,1,1]
-let asciiToNum = (s: string) => s.split('').map(c => c.charCodeAt(0) - 0x61);
+let asciiToNum = (s: string) => s.split('').map(c => c.charCodeAt(0) - 0x61 + 1);
 
 for (let file of fs.readdirSync('F:/bag_of_crafting_recipes')) {
     let id = Number(file.substr(0, file.lastIndexOf('.')));


### PR DESCRIPTION
According to the comment above, "asciiToNum" needed to map each character into a number in the following pattern : a = 1, b =2, c=3... but that's not what's happening currently, it's actually off by one.

This small change should make it correct. I don't know how important it is for other implementations, if it's something that's threatening to break anything I think just correcting the comment would do it too.